### PR TITLE
fix bug when run infer_lyric/melody.sh

### DIFF
--- a/songmass/mass/__init__.py
+++ b/songmass/mass/__init__.py
@@ -5,3 +5,4 @@
 from . import xmasked_seq2seq
 from . import xtransformer
 from . import label_smoothed_cross_entropy_with_align
+from . import song_sequence_generator


### PR DESCRIPTION
sh infer_lyric.sh data_org/processed ./mass songmass.pth
will produce blow erro:

File "/tmp/tmp2l75dct2/fairseq_user_dir_50329/xmasked_seq2seq.py", line 437, in build_generator
ModuleNotFoundError: No module named 'fairseq_user_dir_50329.song_sequence_generator

same as infer_melody.sh
--------
python version is Python 3.7.13
fairseq                0.10.0