### PR TITLE
[Museformer]Update script for running inference directly.

### DIFF
--- a/museformer/README.md
+++ b/museformer/README.md
@@ -125,6 +125,10 @@ The number `10240` indicates the maximum sequence length for calculation.
 
 ## 5. Inference
 
+**To run inference only**, the [Dataset](https://github.com/microsoft/muzic/tree/main/museformer#1-dataset) and [Train](https://github.com/microsoft/muzic/tree/main/museformer#3-train) steps are unnecessary. Only these two steps are required:
+- Ensure the environment settings of [Muzic](https://github.com/microsoft/muzic#requirements) and [Museformer](https://github.com/microsoft/muzic/tree/main/museformer#2-environment).
+- Download the checkpoint [here](https://1drv.ms/u/s!Aq3YEPZCcV5ibz9ySjjNsEB74CQ) and put it in `checkpoints/mf-lmd6remi-1` for inference.
+
 Use the following command to generate 5 music pieces, with the random seed set to 1:
 
 ```bash

--- a/museformer/tgen/generation__mf-lmd6remi-x.sh
+++ b/museformer/tgen/generation__mf-lmd6remi-x.sh
@@ -1,5 +1,17 @@
 DATA_DIR=data-bin/lmd6remi
 MODEL_NAME=mf-lmd6remi-$1
+DICT_SRC_PATH=data/meta/dict.txt
+DICT_AIM_PATH=$DATA_DIR/dict.txt
+
+if ! [ -d $DATA_DIR ]
+then
+  mkdir -p $DATA_DIR
+fi
+
+if ! [ -f $DICT_AIM_PATH ]
+then
+  cp $DICT_SRC_PATH $DICT_AIM_PATH
+fi
 
 OMP_NUM_THREADS=$(cat /proc/cpuinfo| grep "processor"| wc -l)
 NUM_WORKERS=$OMP_NUM_THREADS


### PR DESCRIPTION
Hi, thanks for sharing your great work!
However, I was confused a lot when I just wanted to try Museformer with the inference step. It seems that the inference step only needs a "dict.txt" copied from _data/meta/_ to _data-bin/lmd6remi/_ rather than preparing the whole dataset. That is, the Dataset preparation and the training steps are unnecessary if someone just wants to try Musefomer, is it?
I add some init commands to the inference script. The readme is also updated about this. I think these could make the project clear to those who want to try Museformer.