### PR TITLE
constraintor.py: Fix Python syntax error

### DIFF
--- a/relyme/telemelody_zh/constraintor.py
+++ b/relyme/telemelody_zh/constraintor.py
@@ -84,7 +84,7 @@ class TokenConstraintor():
                 # probs = _config.PitchPara.P_WORST.value
                 probs = self.pitch_ruler._accept_notes(curr_note - prev_note, front, back)
                 
-                Structure Constraint Part
+                # Structure Constraint Part
                 if curr_token in buffer_pitch:
                     probs += _config.PitchPara.P_BEST.value
                 


### PR DESCRIPTION
% `pipx install ruff`
% `ruff --select=E999 .`
```
relyme/telemelody_zh/constraintor.py:87:27: E999 SyntaxError: Unexpected token 'Constraint'
```