### PR TITLE
Ubuntu 16.04 with Python 3.6 devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+	"build": {
+		// Sets the run context to one level up instead of the .devcontainer folder.
+		"context": "..",
+		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+		"dockerfile": "../Dockerfile"
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "devcontainer"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:16.04
+
+WORKDIR /
+RUN apt-get update
+RUN apt-get install -y git gcc g++ make
+RUN apt-get install -y zlib1g zlib1g-dev
+RUN apt-get install -y libssl-dev libncurses5-dev libsqlite3-dev libreadline-dev libtk8.6 libgdm-dev libdb4o-cil-dev libpcap-dev
+RUN apt-get install -y libsasl2-dev libldap2-dev libssl-dev
+
+RUN git clone https://github.com/deadsnakes/python3.6
+WORKDIR /python3.6
+RUN ./configure --enable-optimizations
+RUN make
+RUN make test
+RUN make install
+
+RUN python3.6 -m pip install pip --upgrade
+RUN python3.6 -m pip install wheel
+
+RUN pip3 install pyOpenSSL
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt


### PR DESCRIPTION
I tried to run `clamp` and went through the repository instructions for the environment, since the requirements didn't really work on my Windows or Ubuntu.
In the end it turned out that the [README.md](https://github.com/microsoft/muzic/blob/main/README.md) is misleading and that was all unnecessary to just run clamp. (It has it's own requirements which work on modern Windows)

Whatever the case, I prepared this environment and I don't want it to go to waste.